### PR TITLE
feat: Implement Discord Gateway integration and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Environment variables
+.env
+
+# Node.js
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Ruby
+.bundle/
+.byebug_history
+Gemfile.lock
+*.gem
+*.rbc
+capybara-*.html
+.rspec
+coverage/
+spec/reports/
+tmp/
+
+# Docker
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,41 @@
 # Use the official Ruby image from the Docker Hub
-FROM ruby:3.4
+FROM ruby:3.4-alpine3.20
+
+ENV BUNDLE_DEPLOYMENT=1 \
+    BUNDLE_WITHOUT=development:test \
+    RACK_ENV=production \
+    APP_ENV=production \
+    BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_BIN=/usr/local/bundle/bin \
+    GEM_HOME=/usr/local/bundle \
+    PATH="$BUNDLE_BIN:$PATH"
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
-# Copy the Gemfile and Gemfile.lock into the container
+# ランタイム
+RUN apk add --no-cache tzdata ca-certificates
+
+# ここを追加（ビルド依存）
+RUN apk add --no-cache --virtual .build-deps build-base ruby-dev
+
+# 依存インストール
 COPY Gemfile Gemfile.lock ./
+RUN bundle lock --add-platform x86_64-linux-musl && bundle install --jobs 4 --retry 3
+RUN apk del .build-deps
 
-# Install the gems
-RUN bundle install
-
-# Copy the application code into the container
+# アプリ本体
 COPY . .
+
+# 最終ロックにも musl を付与（上の COPY で lock が戻るのを防ぐ）
+RUN bundle lock --add-platform x86_64-linux-musl
+
+# ここを追加：最終チェック。不足があれば一時的にビルド依存を入れて再インストール
+RUN bundle check || (apk add --no-cache --virtual .build-deps build-base ruby-dev && bundle install --jobs 4 --retry 3 && apk del .build-deps)
+
+# 非rootで実行
+RUN adduser -D -h /usr/src/app app && chown -R app:app /usr/src/app /usr/local/bundle
+USER app
 
 # Expose the port the app runs on
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN bundle install
 COPY . .
 
 # Expose the port the app runs on
-EXPOSE 4568
+EXPOSE 8080
 
 # The command to run the application
 CMD ["bundle", "exec", "ruby", "app.rb", "-o", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Web + utilities
 gem 'sinatra'
 gem 'sinatra-contrib'
-gem 'sinatra-reloader'
+# sinatra-reloader は開発時のみ
 
 gem "rackup", "~> 2.2"
 gem "puma", "~> 6.6"
@@ -16,3 +16,8 @@ gem 'websocket-client-simple'
 
 # discorb (登録・管理用途に利用可能)
 gem 'discorb'
+
+# 開発専用
+group :development do
+  gem 'sinatra-reloader'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,18 @@
 source 'https://rubygems.org'
 
+# Web + utilities
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'sinatra-reloader'
 
 gem "rackup", "~> 2.2"
 gem "puma", "~> 6.6"
+
+# Discord HTTP Interactions 署名検証（Ed25519）
+gem 'ed25519'
+
+# WebSocketクライアント（バックエンドのWSと通信するため）
+gem 'websocket-client-simple'
+
+# discorb (登録・管理用途に利用可能)
+gem 'discorb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
 PLATFORMS
   x64-mingw-ucrt
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   discorb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,63 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    async (1.30.3)
+      console (~> 1.10)
+      nio4r (~> 2.3)
+      timers (~> 4.1)
+    async-http (0.56.6)
+      async (>= 1.25)
+      async-io (>= 1.28)
+      async-pool (>= 0.2)
+      protocol-http (~> 0.22.0)
+      protocol-http1 (~> 0.14.0)
+      protocol-http2 (~> 0.14.0)
+      traces (~> 0.4.0)
+    async-io (1.43.2)
+      async
+    async-pool (0.10.3)
+      async (>= 1.25)
+    async-websocket (0.19.2)
+      async-http (~> 0.54)
+      async-io (~> 1.23)
+      protocol-websocket (~> 0.7.0)
     base64 (0.3.0)
+    console (1.33.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
+    discorb (0.20.0)
+      async (~> 1.30.1)
+      async-http (~> 0.56.5)
+      async-websocket (~> 0.19.0)
+      mime-types (~> 3.3)
+    ed25519 (1.4.0)
+    event_emitter (0.2.6)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
+    json (2.13.2)
     logger (1.7.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0805)
     multi_json (1.17.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.3.0)
     nio4r (2.7.4)
+    protocol-hpack (1.5.1)
+    protocol-http (0.22.9)
+    protocol-http1 (0.14.6)
+      protocol-http (~> 0.22)
+    protocol-http2 (0.14.2)
+      protocol-hpack (~> 1.4)
+      protocol-http (~> 0.18)
+    protocol-websocket (0.7.5)
+      protocol-http (~> 0.2)
+      protocol-http1 (~> 0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     rack (3.1.16)
@@ -36,17 +87,28 @@ GEM
     sinatra-reloader (1.0)
       sinatra-contrib
     tilt (2.6.1)
+    timers (4.4.0)
+    traces (0.4.1)
+    websocket (1.2.11)
+    websocket-client-simple (0.9.0)
+      base64
+      event_emitter
+      mutex_m
+      websocket
 
 PLATFORMS
   x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
+  discorb
+  ed25519
   puma (~> 6.6)
   rackup (~> 2.2)
   sinatra
   sinatra-contrib
   sinatra-reloader
+  websocket-client-simple
 
 BUNDLED WITH
    2.6.3

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 koduki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with the Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,0 @@
-Doppel
-Copyright 2025 koduki
-
-This product includes software developed at
-koduki (https://github.com/koduki).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Doppel
+Copyright 2025 koduki
+
+This product includes software developed at
+koduki (https://github.com/koduki).

--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ The web interface will be available at `http://localhost:8080`.
 *   **Web UI Streaming:** The `/stream` endpoint uses Server-Sent Events (SSE) to push data from the backend to the browser.
 *   **Discord Bot:** The `discorb` gem connects to the Discord Gateway API to receive and respond to messages in real-time.
 *   **Backend Communication:** The application communicates with its backend, [gemini-cli-proxy](https://github.com/koduki/gemini-cli-proxy). It creates a session via a POST request and then establishes a WebSocket connection for streaming the chat conversation.
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-docker compose up --build 
+# Doppel
+
+Doppel is a Sinatra-based application that serves as a bridge between various frontends and gemini-cli. It provides a web interface with Server-Sent Events (SSE) for real-time communication and integrates a Discord bot that responds to DMs and mentions.
+
+This application is designed to work with [koduki/gemini-cli-proxy](https://github.com/koduki/gemini-cli-proxy) as its gemini-cli wrapper.
+
+## Features
+
+*   **Web Interface:** A simple web UI to interact with the backend service.
+*   **Real-time Streaming:** Uses Server-Sent Events (SSE) to stream responses to the web UI.
+*   **Discord Bot Integration:** A fully integrated Discord bot using the `discorb` gem.
+    *   Responds to Direct Messages (DMs).
+    *   Responds to @mentions in server channels.
+    *   Streams responses from the backend service directly into Discord messages by progressively editing them.
+*   **Dockerized:** Comes with `Dockerfile` and `docker-compose.yaml` for easy setup and deployment.
+
+## Requirements
+
+*   Docker
+*   Docker Compose
+*   A running instance of [gemini-cli-proxy](https://github.com/koduki/gemini-cli-proxy)
+
+## Setup
+
+1.  **Set up the backend service:**
+    This application requires the [gemini-cli-proxy](https://github.com/koduki/gemini-cli-proxy) to be running as the backend. Please follow the setup instructions in its repository first.
+
+2.  **Clone this repository:**
+    ```bash
+    git clone <repository-url>
+    cd doppel
+    ```
+
+3.  **Create the environment file:**
+    Create a file named `.env` in the project root and add the following variables.
+
+    ```env
+    # The base URL for the backend AI service (gemini-cli-proxy)
+    APP_BACKEND_ORIGIN=http://your-backend-service-url:3000/
+
+    # Your Discord Bot Token
+    DISCORD_TOKEN=your-discord-bot-token-here
+    ```
+
+    *   `APP_BACKEND_ORIGIN`: The application connects to `{APP_BACKEND_ORIGIN}api/chat` via HTTP to create sessions and to `{APP_BACKEND_ORIGIN}` via WebSocket for streaming.
+    *   `DISCORD_TOKEN`: Required to run the Discord bot. If this is not provided, the bot will not start.
+
+## Usage
+
+To start the application, run the following command:
+
+```bash
+docker-compose up
+```
+
+The web interface will be available at `http://localhost:8080`.
+
+## How It Works
+
+*   **Web Server:** `Sinatra` handles HTTP requests.
+*   **Web UI Streaming:** The `/stream` endpoint uses Server-Sent Events (SSE) to push data from the backend to the browser.
+*   **Discord Bot:** The `discorb` gem connects to the Discord Gateway API to receive and respond to messages in real-time.
+*   **Backend Communication:** The application communicates with its backend, [gemini-cli-proxy](https://github.com/koduki/gemini-cli-proxy). It creates a session via a POST request and then establishes a WebSocket connection for streaming the chat conversation.

--- a/app.rb
+++ b/app.rb
@@ -1,9 +1,161 @@
 require 'sinatra'
 require 'sinatra/json'
 require 'sinatra/reloader' if development?
+require 'ed25519'
+require 'base64'
+require 'json'
+require 'net/http'
+require 'uri'
+require 'websocket-client-simple'
 
-set :port, 4568
+set :port, ENV.fetch('PORT', '8080').to_i
+set :bind, '0.0.0.0'
+
+BACKEND_HTTP = ENV.fetch('BACKEND_HTTP', 'http://34.172.102.142:3000/api/chat')
+BACKEND_WS   = ENV.fetch('BACKEND_WS',   'ws://34.172.102.142:3000/')
+
+DISCORD_PUBLIC_KEY = ENV['DISCORD_PUBLIC_KEY']
+DISCORD_APP_ID     = ENV['DISCORD_APP_ID']
+DISCORD_TOKEN      = ENV['DISCORD_TOKEN']
 
 get '/' do
   erb :index
+end
+
+# Discord HTTP Interactions entrypoint for Cloud Run
+post '/interactions' do
+  request.body.rewind
+  raw_body = request.body.read
+  timestamp = request.env['HTTP_X_SIGNATURE_TIMESTAMP']
+  signature = request.env['HTTP_X_SIGNATURE_ED25519']
+
+  halt 401, 'Bad request signature' unless valid_discord_signature?(timestamp, raw_body, signature)
+
+  interaction = JSON.parse(raw_body)
+
+  # PING -> PONG
+  if interaction['type'] == 1
+    content_type :json
+    return JSON.generate({ type: 1 })
+  end
+
+  # Application Command or Message Component
+  # まずACK (type 5) で遅延レスポンス
+  token = interaction['token']
+  app_id = DISCORD_APP_ID
+  # DiscordはACK(type 5)で遅延レスポンスを期待するため、即時200 with {type:5} を返す
+  Thread.new do
+    begin
+      user_prompt = extract_prompt(interaction)
+      response_text = fetch_response_via_backend(user_prompt)
+      edit_original_response(token, app_id, response_text)
+    rescue => e
+      edit_original_response(token, app_id, "エラーが発生しました: #{e.message}")
+    end
+  end
+
+  status 200
+  content_type :json
+  JSON.generate({ type: 5 })
+end
+
+helpers do
+  def valid_discord_signature?(timestamp, body, signature)
+    return false if DISCORD_PUBLIC_KEY.to_s.strip.empty?
+    verify_key = Ed25519::VerifyKey.new([DISCORD_PUBLIC_KEY].pack('H*'))
+    message = timestamp + body
+    begin
+      verify_key.verify([signature].pack('H*'), message)
+      true
+    rescue Ed25519::VerifyError
+      false
+    end
+  end
+
+  def extract_prompt(interaction)
+    # スラッシュコマンドのオプションやメッセージ内容からテキストを抽出
+    if interaction['data'] && interaction['data']['options']&.any?
+      first = interaction['data']['options'].first
+      first['value'].to_s
+    elsif interaction['data'] && interaction['data']['name']
+      interaction['data']['name'].to_s
+    else
+      'こんにちは'
+    end
+  end
+
+  def fetch_response_via_backend(prompt)
+    # 1) セッション作成 (HTTP)
+    session_id = create_session
+
+    # 2) WS接続してストリーミングを受信
+    collected = String.new
+    ws = WebSocket::Client::Simple.connect(BACKEND_WS)
+
+    ready = false
+    mutex = Mutex.new
+    cond = ConditionVariable.new
+
+    ws.on(:open) do
+      ws.send({ type: 'init', sessionId: session_id }.to_json)
+    end
+
+    ws.on(:message) do |evt|
+      msg = JSON.parse(evt.data) rescue nil
+      next unless msg
+      case msg['type']
+      when 'ready'
+        ready = true
+        ws.send({ type: 'message', content: prompt }.to_json)
+      when 'stream_chunk'
+        if msg.dig('data', 'type') == 'content'
+          collected << msg.dig('data', 'data').to_s
+        end
+      when 'stream_end'
+        mutex.synchronize { cond.signal }
+      when 'error'
+        collected << "\n[Error] #{msg['error']}"
+        mutex.synchronize { cond.signal }
+      end
+    end
+
+    # タイムアウト
+    Thread.new do
+      sleep 20
+      mutex.synchronize { cond.signal }
+    end
+
+    mutex.synchronize { cond.wait(mutex) }
+    ws.close
+
+    collected.empty? ? '応答がありませんでした。' : collected
+  end
+
+  def create_session
+    uri = URI.parse(BACKEND_HTTP)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    req = Net::HTTP::Post.new(uri.request_uri)
+    res = http.request(req)
+
+    raise "セッション作成に失敗しました (#{res.code})" unless res.is_a?(Net::HTTPSuccess)
+
+    body = JSON.parse(res.body)
+    body['sessionId'] || raise('sessionId が取得できませんでした')
+  end
+
+  def edit_original_response(token, app_id, content)
+    uri = URI("https://discord.com/api/v10/webhooks/#{app_id}/#{token}/messages/@original")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    req = Net::HTTP::Patch.new(uri.request_uri, { 'Content-Type' => 'application/json' })
+    req.body = { content: content }.to_json
+    res = http.request(req)
+
+    unless res.is_a?(Net::HTTPSuccess)
+      warn "Discord edit message failed: #{res.code} #{res.body}"
+    end
+  end
 end

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,9 @@ services:
   app:
     build: .
     ports:
-      - "4568:4568"
+      - "8080:8080"
     volumes:
       - .:/usr/src/app
+    environment:
+      - PORT=8080
     command: ["bundle", "exec", "ruby", "app.rb", "-o", "0.0.0.0"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,10 +6,8 @@ services:
       - "8080:8080"
     volumes:
       - .:/usr/src/app
+    env_file:
+      - .env
     environment:
       - PORT=8080
-      - SSE_TIMEOUT_SEC=5
-      - DISCORD_WAIT_TIMEOUT_SEC=20
-      - HTTP_OPEN_TIMEOUT_SEC=3
-      - HTTP_READ_TIMEOUT_SEC=3
     command: ["bundle", "exec", "ruby", "app.rb", "-o", "0.0.0.0"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,4 +8,8 @@ services:
       - .:/usr/src/app
     environment:
       - PORT=8080
+      - SSE_TIMEOUT_SEC=5
+      - DISCORD_WAIT_TIMEOUT_SEC=20
+      - HTTP_OPEN_TIMEOUT_SEC=3
+      - HTTP_READ_TIMEOUT_SEC=3
     command: ["bundle", "exec", "ruby", "app.rb", "-o", "0.0.0.0"]

--- a/views/index.erb
+++ b/views/index.erb
@@ -53,7 +53,7 @@
   
         async function createSession() {  
             try {  
-                const response = await fetch('http://localhost:3000/api/chat', { method: 'POST' });  
+                const response = await fetch('http://34.172.102.142:3000/api/chat', { method: 'POST' });  
                 const data = await response.json();  
                 sessionId = data.sessionId;  
                   
@@ -65,7 +65,7 @@
         }  
   
         function connectWebSocket() {  
-            ws = new WebSocket(`ws://localhost:3000`);  
+            ws = new WebSocket(`ws://34.172.102.142:3000/`);  
               
             ws.onopen = () => {  
                 ws.send(JSON.stringify({ type: 'init', sessionId }));  

--- a/views/index.erb
+++ b/views/index.erb
@@ -50,27 +50,27 @@
     <script>  
         // 同一オリジンのSSEで中継するため、外部HTTP/WSへは直接アクセスしない
         let currentStream = null;
-
+  
         function createSession() {  
             addMessage('System', 'Ready.', 'system-message');  
         }
-
+  
         function sendMessage() {  
             const input = document.getElementById('message-input');  
             const message = input.value.trim();  
             if (!message) return;  
-
+  
             // 前のストリームがあれば閉じる
             if (currentStream) { currentStream.close(); currentStream = null; }
-
+  
             addMessage('You', message, 'user-message');  
             addMessage('Gemini', '', 'ai-message');
-
+  
             // 同一オリジンのSSEに接続
             const url = `/stream?prompt=${encodeURIComponent(message)}`;
             const es = new EventSource(url);
             currentStream = es;
-
+  
             es.onmessage = (e) => {
                 appendToLastMessage(e.data);
             };
@@ -79,11 +79,22 @@
                 currentStream = null;
             });
             es.addEventListener('error', (e) => {
-                addMessage('Error', 'Streaming error.', 'error-message');
+                const state = ['CONNECTING','OPEN','CLOSED'][es.readyState] || es.readyState;
+                addMessage('Error', `Streaming error. state=${state}`, 'error-message');
+                try {
+                  addMessage('Error', `event=${JSON.stringify(e)}`, 'error-message');
+                } catch {}
                 es.close();
                 currentStream = null;
             });
 
+            // サーバ側が送る backend_error イベント
+            es.addEventListener('backend_error', (e) => {
+                if (e.data) {
+                  addMessage('Backend', e.data, 'error-message');
+                }
+            });
+  
             input.value = '';
         }  
   

--- a/views/index.erb
+++ b/views/index.erb
@@ -39,7 +39,7 @@
 </head>  
 <body>  
     <div id="chat-container">  
-        <h1>Doppel Engineer</h1>  
+        <h1>Doppel Engineer2</h1>  
         <div id="messages"></div>  
         <div id="input-container">  
             <input type="text" id="message-input" placeholder="Enter a message..." />  

--- a/views/index.erb
+++ b/views/index.erb
@@ -48,75 +48,43 @@
     </div>  
   
     <script>  
-        let sessionId = null;  
-        let ws = null;  
-  
-        async function createSession() {  
-            try {  
-                const response = await fetch('http://34.172.102.142:3000/api/chat', { method: 'POST' });  
-                const data = await response.json();  
-                sessionId = data.sessionId;  
-                  
-                connectWebSocket();  
-                addMessage('System', 'Session created successfully.', 'ai-message');  
-            } catch (error) {  
-                addMessage('Error', 'Failed to create session: ' + error.message, 'error-message');  
-            }  
-        }  
-  
-        function connectWebSocket() {  
-            ws = new WebSocket(`ws://34.172.102.142:3000/`);  
-              
-            ws.onopen = () => {  
-                ws.send(JSON.stringify({ type: 'init', sessionId }));  
-            };  
-  
-            ws.onmessage = (event) => {  
-                const message = JSON.parse(event.data);  
-                handleWebSocketMessage(message);  
-            };  
-  
-            ws.onerror = (error) => {  
-                addMessage('Error', 'WebSocket connection error.', 'error-message');  
-            };  
-        }  
-  
-        function handleWebSocketMessage(message) {  
-            switch (message.type) {  
-                case 'ready':  
-                    addMessage('System', 'WebSocket connection established.', 'system-message');  
-                    break;  
-                case 'stream_chunk':  
-                    if (message.data.type === 'content') {  
-                        appendToLastMessage(message.data.data);  
-                    }  
-                    break;  
-                case 'stream_end':  
-                    // Streaming finished
-                    break;  
-                case 'tool_result':
-                    addMessage('Tool', `${message.data.toolName}: ${message.data.result || 'Completed'}`, 'tool-message');
-                    break;
-                case 'tool_error':
-                    addMessage('Tool Error', `${message.data.toolName}: ${message.data.error}`, 'error-message');
-                    break;
-                case 'error':  
-                    addMessage('Error', message.error, 'error-message');  
-                    break;  
-            }  
-        }  
-  
+        // 同一オリジンのSSEで中継するため、外部HTTP/WSへは直接アクセスしない
+        let currentStream = null;
+
+        function createSession() {  
+            addMessage('System', 'Ready.', 'system-message');  
+        }
+
         function sendMessage() {  
             const input = document.getElementById('message-input');  
             const message = input.value.trim();  
-              
-            if (!message || !ws) return;  
-  
+            if (!message) return;  
+
+            // 前のストリームがあれば閉じる
+            if (currentStream) { currentStream.close(); currentStream = null; }
+
             addMessage('You', message, 'user-message');  
-            addMessage('Gemini', '', 'ai-message'); // Prepare an empty AI response
-              
-            ws.send(JSON.stringify({ type: 'message', content: message }));  
-            input.value = '';  
+            addMessage('Gemini', '', 'ai-message');
+
+            // 同一オリジンのSSEに接続
+            const url = `/stream?prompt=${encodeURIComponent(message)}`;
+            const es = new EventSource(url);
+            currentStream = es;
+
+            es.onmessage = (e) => {
+                appendToLastMessage(e.data);
+            };
+            es.addEventListener('end', (e) => {
+                es.close();
+                currentStream = null;
+            });
+            es.addEventListener('error', (e) => {
+                addMessage('Error', 'Streaming error.', 'error-message');
+                es.close();
+                currentStream = null;
+            });
+
+            input.value = '';
         }  
   
         function addMessage(sender, content, className) {  

--- a/views/index.erb
+++ b/views/index.erb
@@ -39,7 +39,7 @@
 </head>  
 <body>  
     <div id="chat-container">  
-        <h1>Doppel Engineer2</h1>  
+        <h1>Doppel Engineer</h1>  
         <div id="messages"></div>  
         <div id="input-container">  
             <input type="text" id="message-input" placeholder="Enter a message..." />  
@@ -48,7 +48,6 @@
     </div>  
   
     <script>  
-        // 同一オリジンのSSEで中継するため、外部HTTP/WSへは直接アクセスしない
         let currentStream = null;
   
         function createSession() {  


### PR DESCRIPTION
This pull request resolves the initial issue where the Discord bot was unresponsive to mentions. It replaces the old, non-functional webhook approach with a persistent Gateway connection using the `discorb` gem.

Key changes include:
- **Discord Gateway Integration**: Implemented a `discorb` client that connects to the Discord Gateway, listens for DMs and mentions, and streams responses from the backend.
- **Bug Fixes**:
    - Correctly configured privileged intents (`GUILDS`, `MEMBERS`, `MESSAGE_CONTENT`).
    - Fixed mention detection by using a robust regex search on the message content.
    - Resolved several `NoMethodError` issues related to `discorb`'s async API.
- **Refactoring & Cleanup**:
    - Moved helper methods to be globally accessible.
    - Removed unused code and constants related to the old Discord Webhook implementation.
- **Configuration Management**:
    - Moved sensitive keys and environment-specific settings to a `.env` file.
    - Added `.gitignore` to exclude the `.env` file.
- **Documentation**:
    - Created a comprehensive `README.md`.
    - Added an `Apache-2.0` `LICENSE` file and updated the copyright information.
